### PR TITLE
fix active scope sign standard

### DIFF
--- a/app/models/sign_standard.rb
+++ b/app/models/sign_standard.rb
@@ -99,7 +99,7 @@ class SignStandard < ActiveRecord::Base
   end
 
   def self.active
-    where('voided_on_date IS NULL OR voided_on_date < ?', Date.today)
+    where('voided_on_date IS NULL OR voided_on_date > ?', Date.today)
   end
 
   #------------------------------------------------------------------------------


### PR DESCRIPTION
@smeeks I believe the logic is just the other way around. Take a look at `.voided?`. Regardless this class method is never called. Just wanted a second set of eyes. Thanks!
